### PR TITLE
Throwing an error if unable to pull "/rooms" in Campfire.rooms.

### DIFF
--- a/lib/campfire.js
+++ b/lib/campfire.js
@@ -15,6 +15,10 @@ var Campfire = function(options) {
 Campfire.prototype.rooms = function(callback) {
   var self = this;
   this.get('/rooms', function(data) {
+    if (typeof data != 'object') {
+      throw new Error('Encountered an error and the call to Campfire.rooms failed. Verify that your credentials are correct.');
+    }
+
     callback(data.rooms.map(function(roomData) {
       return new Campfire.Room(self, roomData);
     }));
@@ -197,5 +201,9 @@ Campfire.Room.prototype.get = function(path, callback) {
 Campfire.Room.prototype.post = function(path, body, callback) {
   this.campfire.post(this.path + path, body, callback);
 };
+
+process.on('uncaughtException', function(err) {
+  console.warn(err.message);
+});
 
 exports.Campfire = Campfire;


### PR DESCRIPTION
Should fix up most instance of #2 occurring when people don't supply the proper credentials.
